### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-#sp-slidemenu.js
+# sp-slidemenu.js
 
 ## ※Caution!!
 There seems to be a bug in some old Android devices.
@@ -7,12 +7,12 @@ I am sorry.
 I ended up selling the old Android device. Therefore, I will not be able to reproduce the bug. 
 So, I do not have to fix the bug yet.
 
-##About
+## About
 sp-slidemenu.js is a JavaScript library that provides UI of slide menu.
 
 See [demo](http://be-hase.com.s3.amazonaws.com/static/sp-slidemenu/sample/demo1.html)
 
-##Support browser
+## Support browser
 * Mobile
   - iOS Safari (iOS4+)
   - Android Browser (Android 2.2+)
@@ -26,9 +26,9 @@ See [demo](http://be-hase.com.s3.amazonaws.com/static/sp-slidemenu/sample/demo1.
   - Firefox
   - Safari
   
-##Getting Started
+## Getting Started
 
-###1. Download and load.
+### 1. Download and load.
 Download code.  
 And load script like below.  
 
@@ -38,7 +38,7 @@ And load script like below.
 
 *sp-slidemenu.js is not dependent other library.
 
-###2. Write HTML
+### 2. Write HTML
 
 ```
 <body>
@@ -75,7 +75,7 @@ And load script like below.
 * "#main" element : Required. Bad you can use your favorite selector.  
 * ".menu-button" element : Required. Bad you can use your favorite selector. When Clicked, toggle(open or close) slidemenu. 
 
-###3. Write CSS
+### 3. Write CSS
 
 ```css
 #main {
@@ -102,13 +102,13 @@ And load script like below.
 }
 ```
 
-###4. Write JavaScript
+### 4. Write JavaScript
 
 ```javascript
 SpSlidemenu('#main', '.slidemenu', '.menu-button', {direction: 'left'});
 ```
 
-###DOM Figure
+### DOM Figure
 
 * **close**
 
@@ -119,9 +119,9 @@ SpSlidemenu('#main', '.slidemenu', '.menu-button', {direction: 'left'});
 ![image1](http://be-hase.com.s3.amazonaws.com/static/img/SpSlidemenu/image2.png)
 
 
-##Document
+## Document
 
-###Function
+### Function
 
 ```
 SpSlidemenu(main, slidemenu, button, options)
@@ -140,7 +140,7 @@ SpSlidemenu(main, slidemenu, button, options)
 var sp_slidemenu = SpSlidemenu('#main', '.slidemenu', '.menu-button', {direction: 'left'});
 ```
 
-###Option
+### Option
 
 name | type | default | description
 ------------ | ------------- | ------------ | ------------
@@ -148,7 +148,7 @@ disableCssAnimation | Boolean | false | Use JavaScript Animation. You should set
 disable3d | Boolean | false | When support 3D transform browser and this option set true, it is not used 3D transform and use 2D transform. You should set true, when it is a device which has a bug in 3D transform(old Android or BlackBerry etc).
 direction | String | left | left or right.
 
-###Method
+### Method
 **slideOpen**  
 Open slidemenu.
 
@@ -166,6 +166,6 @@ sp_slidemenu.slideClose();
 ```
 
 
-##Demo & Sample
+## Demo & Sample
 
 Demo : [Click here!](http://be-hase.com.s3.amazonaws.com/static/sp-slidemenu/sample/demo1.html)


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
